### PR TITLE
fixes extrafanart limit counter

### DIFF
--- a/default.py
+++ b/default.py
@@ -471,7 +471,6 @@ class Main:
             for item in self.image_list:
                 final_image_list.append(item)
         for artwork in final_image_list:
-            imageurl = artwork['url']
             if image_type == artwork['type']:
                 ### check if script has been cancelled by user
                 if dialog('iscanceled', background = self.settings.background):
@@ -481,7 +480,7 @@ class Main:
                     break
                 # File naming
                 if art_type == 'extrafanart' and self.mediatype == 'movie':
-                    artworkfile = imageurl.rsplit('/', 1)[1]
+                    artworkfile = artwork['url'].rsplit('/', 1)[1]
                 elif art_type == 'extrafanart' and self.mediatype == 'tvshow':
                     artworkfile = ('%s.jpg'% artwork['id'])
                 elif art_type == 'extrathumbs':
@@ -492,7 +491,7 @@ class Main:
                     artworkfile = (filename+'%s.jpg' % artwork['season'])
                 else: artworkfile = filename
                 image = {}
-                image['url'] = imageurl
+                image['url'] = artwork['url']
                 image['filename'] = artworkfile
                 image['targetdirs'] = targetdirs
                 image['media_name'] = self.media_name

--- a/default.py
+++ b/default.py
@@ -513,18 +513,23 @@ class Main:
         if len(image_list) == 0:
             log('Nothing to download')
         else:
-            apply_filters_counter = 0
             log('Starting download')
+            image_counter = limit_counter = 0
+            currentmedia = currenttype = ''
             download_list = []
             # Check for set limits
             for image in image_list:
                 if (self.mode == 'gui' or self.mode == 'customgui') and not image['artwork_type'] == 'extrafanart' and not image['artwork_type'] == 'extrathumbs':
                     download_list = image_list
                 else:
+                    if not currentmedia == image['media_name'] and not currenttype == image['media_type']:
+                        currentmedia = image['media_name']
+                        currenttype = image['media_type']
+                        limit_counter = 0                        
                     # Check for set limits
-                    limited = self.filters.do_filter(image['artwork_type'], image['media_type'], image['artwork_details'], image['artwork_number'])
+                    limited = self.filters.do_filter(image['artwork_type'], image['media_type'], image['artwork_details'], limit_counter)
                     if limited[0] and image['artwork_type'] =='extrafanart':
-                        self.fileops._delete_file_in_dirs(image['filename'], image['targetdirs'], limited[1])
+                        self.fileops._delete_file_in_dirs(image['filename'], image['targetdirs'], limited[1],image['media_name'])
                     elif limited[0]:
                         log("[%s] Ignoring (%s): %s" % (image['media_name'],limited[1], image['filename']))
                         # Check if artwork doesn't exist and the one available below settings
@@ -543,8 +548,10 @@ class Main:
                                 download_list.append(image)
                             else:
                                 log("[%s] Ignoring (Exists in all target directories): %s" % (image['media_name'],image['filename']) )
-                apply_filters_counter = apply_filters_counter + 1
-                dialog('update', percentage = int(float(apply_filters_counter) / float(len(image_list)) * 100.0), line1 = __localize__(32021), background = self.settings.background)
+                            if currentmedia == image['media_name'] and currenttype == image['media_type']:
+                                limit_counter = limit_counter+1
+                image_counter = image_counter + 1
+                dialog('update', percentage = int(float(image_counter) / float(len(image_list)) * 100.0), line1 = __localize__(32021), background = self.settings.background)
             
             # Download artwork that passed the limit check
             for image in download_list:

--- a/default.py
+++ b/default.py
@@ -515,17 +515,19 @@ class Main:
         else:
             log('Starting download')
             image_counter = limit_counter = 0
-            currentmedia = currenttype = ''
+            currentmedia = ''
+            currenttype = ''
             download_list = []
             # Check for set limits
             for image in image_list:
+                if not currenttype == image['artwork_type']:
+                    currenttype = image['artwork_type']
+                    limit_counter = 0
+                    if not currentmedia == image['media_name']:
+                        currentmedia = image['media_name']
                 if (self.mode == 'gui' or self.mode == 'customgui') and not image['artwork_type'] == 'extrafanart' and not image['artwork_type'] == 'extrathumbs':
                     download_list = image_list
                 else:
-                    if not currentmedia == image['media_name'] and not currenttype == image['media_type']:
-                        currentmedia = image['media_name']
-                        currenttype = image['media_type']
-                        limit_counter = 0                        
                     # Check for set limits
                     limited = self.filters.do_filter(image['artwork_type'], image['media_type'], image['artwork_details'], limit_counter)
                     if limited[0] and image['artwork_type'] =='extrafanart':
@@ -548,8 +550,7 @@ class Main:
                                 download_list.append(image)
                             else:
                                 log("[%s] Ignoring (Exists in all target directories): %s" % (image['media_name'],image['filename']) )
-                            if currentmedia == image['media_name'] and currenttype == image['media_type']:
-                                limit_counter = limit_counter+1
+                        limit_counter = limit_counter + 1
                 image_counter = image_counter + 1
                 dialog('update', percentage = int(float(image_counter) / float(len(image_list)) * 100.0), line1 = __localize__(32021), background = self.settings.background)
             

--- a/resources/lib/fileops.py
+++ b/resources/lib/fileops.py
@@ -93,7 +93,7 @@ class fileops:
         return thumbpath         
 
     # copy filen from temp to final location
-    def _copyfile(self, sourcepath, targetpath):
+    def _copyfile(self, sourcepath, targetpath, media_name = ''):
         targetdir = os.path.dirname(targetpath)
         if not self._exists(targetdir):
             if not self._mkdir(targetdir):
@@ -101,7 +101,7 @@ class fileops:
         if not self._copy(sourcepath, targetpath):
             raise CopyError(targetpath)
         else:
-            log("Copied successfully: %s" % targetpath)
+            log("[%s] Copied successfully: %s" % (media_name, targetpath) )
 
     # download file
     def _downloadfile(self, url, filename, targetdirs, media_name):
@@ -132,6 +132,6 @@ class fileops:
             self.downloadcount = self.downloadcount + 1
             for targetdir in targetdirs:
                 targetpath = os.path.join(targetdir, filename)
-                self._copyfile(temppath, targetpath)
+                self._copyfile(temppath, targetpath, media_name)
                 if self.settings.xbmc_caching_enabled:
                     self.erase_current_cache(targetpath)

--- a/resources/lib/fileops.py
+++ b/resources/lib/fileops.py
@@ -49,16 +49,16 @@ class fileops:
         return xbmcvfs.copy(source, target)
 
     ### Delete file from all targetdirs
-    def _delete_file_in_dirs(self, filename, targetdirs, reason):
+    def _delete_file_in_dirs(self, filename, targetdirs, reason, media_name = '' ):
         isdeleted = False
         for targetdir in targetdirs:
             path = os.path.join(targetdir, filename)
             if self._exists(path):
                 self._delete(path)
-                log("Deleted (%s): %s" % (reason, path), xbmc.LOGNOTICE)
+                log("[%s] Deleted (%s): %s" % (media_name, reason, path), xbmc.LOGNOTICE)
                 isdeleted = True
         if not isdeleted:
-            log("Ignoring (%s): %s" % (reason, filename))
+            log("[%s] Ignoring (%s): %s" % (media_name, reason, filename))
 
     ### erase old cache file and copy new one
     def erase_current_cache(self,filename):
@@ -128,7 +128,7 @@ class fileops:
         except socket.timeout, e:
             raise HTTPTimeout(url)
         else:
-            log("Downloaded (%s): %s" % (media_name, filename), xbmc.LOGNOTICE)
+            log("[%s] Downloaded: %s" % (media_name, filename), xbmc.LOGNOTICE)
             self.downloadcount = self.downloadcount + 1
             for targetdir in targetdirs:
                 targetpath = os.path.join(targetdir, filename)


### PR DESCRIPTION
@paddycarey 
potential fix on the total artwork limit that was introduced when doing the batch download re-work.

This works however for most of the artwork except for extrathumbs. So that why i don't merge right away.
One possibility is move the filename of the extrathumbs to the limiter section.

The other one is move the limit section back to the retrieving image list (that will defy the whole intention i think).

Also added the media_name to the reason log message so you know what has been rejected.

Suggestions?
