### PR TITLE
Added license information

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -77,6 +77,7 @@
     <disclaimer lang="zh">错误报告、功能需求及常见问题，请访问XBMC论坛的Artwork Downloader专贴。</disclaimer>
     <language></language>
     <platform>all</platform>
+    <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
     <website></website>
     <source>https://github.com/XBMC-Addons/script.artwork.downloader</source>
     <forum>http://forum.xbmc.org/showthread.php?tid=114633</forum>


### PR DESCRIPTION
Needed to automatically fill field on http://kodi.wiki and http://addons.kodi.tv/ sites.
